### PR TITLE
Copy all files before go mod download

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,6 @@ ENV COSMOS_BUILD_OPTIONS nostrip
 WORKDIR /src 
 
 COPY . .
-# COPY go.mod go.sum ./
 RUN go mod download
 
 # Make the binary

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,9 +10,9 @@ ENV COSMOS_BUILD_OPTIONS nostrip
 # Set working directory for the build
 WORKDIR /src 
 
-COPY go.mod go.sum ./
-RUN go mod download
 COPY . .
+# COPY go.mod go.sum ./
+RUN go mod download
 
 # Make the binary
 RUN env GOOS=$TARGETOS GOARCH=$TARGETARCH make build 


### PR DESCRIPTION
This resolves builds not working when coming from optimint and ethermint's build-evmos GH actions. 