### PR TITLE
Use Ethermint v0.11.0+0.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -239,6 +239,6 @@ require (
 replace (
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.1.7-0.20210622111912-ef00f8ac3d76
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
-	github.com/tharsis/ethermint => github.com/jbowen93/ethermint v0.6.1-0.20220315195256-b5fa45e9887e
+	github.com/tharsis/ethermint => github.com/celestiaorg/ethermint v0.11.1-0.20220322203052-989ea44a5f74
 	google.golang.org/grpc => google.golang.org/grpc v1.33.2
 )

--- a/go.mod
+++ b/go.mod
@@ -239,6 +239,6 @@ require (
 replace (
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.1.7-0.20210622111912-ef00f8ac3d76
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
-	github.com/tharsis/ethermint => github.com/celestiaorg/ethermint v0.11.1-0.20220322203052-989ea44a5f74
+	github.com/tharsis/ethermint => github.com/celestiaorg/ethermint v0.11.1-0.20220323150518-1c1b98ef94c6
 	google.golang.org/grpc => google.golang.org/grpc v1.33.2
 )

--- a/go.sum
+++ b/go.sum
@@ -207,8 +207,8 @@ github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7
 github.com/c-bata/go-prompt v0.2.2/go.mod h1:VzqtzE2ksDBcdln8G7mk2RX9QyGjH+OVqOCSiVIqS34=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/casbin/casbin/v2 v2.37.0/go.mod h1:vByNa/Fchek0KZUgG5wEsl7iFsiviAYKRtgrQfcJqHg=
-github.com/celestiaorg/ethermint v0.11.1-0.20220322203052-989ea44a5f74 h1:3APZ1LlIlu+V4Xf0p//7WLBq09aIeleXp1KpzygNNxU=
-github.com/celestiaorg/ethermint v0.11.1-0.20220322203052-989ea44a5f74/go.mod h1:MuKw2MFm3cvOyk7uMIEKl2x3BeF2UHxJrDh74ZgbVfg=
+github.com/celestiaorg/ethermint v0.11.1-0.20220323150518-1c1b98ef94c6 h1:7SWssHnB2J/IeQpZVXf/kX0U2GGMmjKjYDGz5OY0IaQ=
+github.com/celestiaorg/ethermint v0.11.1-0.20220323150518-1c1b98ef94c6/go.mod h1:MuKw2MFm3cvOyk7uMIEKl2x3BeF2UHxJrDh74ZgbVfg=
 github.com/celestiaorg/optimint v0.1.2 h1:XJMg9mEfQTRsDUyAqzh4/Id7ZCWOml2E7lKH/vvxCfM=
 github.com/celestiaorg/optimint v0.1.2/go.mod h1:CIZ+IHG1Bb/rbh/1wYCMBGt0mV/CdQEFViHkLWNMvsY=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=

--- a/go.sum
+++ b/go.sum
@@ -207,6 +207,8 @@ github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7
 github.com/c-bata/go-prompt v0.2.2/go.mod h1:VzqtzE2ksDBcdln8G7mk2RX9QyGjH+OVqOCSiVIqS34=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/casbin/casbin/v2 v2.37.0/go.mod h1:vByNa/Fchek0KZUgG5wEsl7iFsiviAYKRtgrQfcJqHg=
+github.com/celestiaorg/ethermint v0.11.1-0.20220322203052-989ea44a5f74 h1:3APZ1LlIlu+V4Xf0p//7WLBq09aIeleXp1KpzygNNxU=
+github.com/celestiaorg/ethermint v0.11.1-0.20220322203052-989ea44a5f74/go.mod h1:MuKw2MFm3cvOyk7uMIEKl2x3BeF2UHxJrDh74ZgbVfg=
 github.com/celestiaorg/optimint v0.1.2 h1:XJMg9mEfQTRsDUyAqzh4/Id7ZCWOml2E7lKH/vvxCfM=
 github.com/celestiaorg/optimint v0.1.2/go.mod h1:CIZ+IHG1Bb/rbh/1wYCMBGt0mV/CdQEFViHkLWNMvsY=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
@@ -772,8 +774,6 @@ github.com/jbenet/goprocess v0.0.0-20160826012719-b497e2f366b8/go.mod h1:Ly/wlsj
 github.com/jbenet/goprocess v0.1.3/go.mod h1:5yspPrukOVuOLORacaBi858NqyClJPQxYZlqdZVfqY4=
 github.com/jbenet/goprocess v0.1.4 h1:DRGOFReOMqqDNXwW70QkacFW0YN9QnwLV0Vqk+3oU0o=
 github.com/jbenet/goprocess v0.1.4/go.mod h1:5yspPrukOVuOLORacaBi858NqyClJPQxYZlqdZVfqY4=
-github.com/jbowen93/ethermint v0.6.1-0.20220315195256-b5fa45e9887e h1:rzD1AubuXtlPw+u7dBciXcy+UqpJeyzU7gwEnodpLC0=
-github.com/jbowen93/ethermint v0.6.1-0.20220315195256-b5fa45e9887e/go.mod h1:8j8kbVYb7M4rEWPXJyY5nZ+ur6NepighoQqpqFwi8M0=
 github.com/jedisct1/go-minisign v0.0.0-20190909160543-45766022959e/go.mod h1:G1CVv03EnqU1wYL2dFwXxW2An0az9JTl/ZsqXQeBlkU=
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=


### PR DESCRIPTION
This PR updates evmos to use the celestiaorg/ethermint [v0.11.0+0.1.0 release](https://github.com/celestiaorg/ethermint/releases/tag/v0.11.0%2B0.1.0)